### PR TITLE
Add feature for default values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,6 @@ after_success:
 
 matrix:
   include:
-    - php: 5.3
-      env: setup=lowest
-    - php: 5.3
-      env: setup=stable
     - php: 5.4
       env: setup=lowest
     - php: 5.4

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ use Bryse\Enums\Enum;
 
 class UserStatus extends Enum
 {
+    protected $__default = self::PENDING;
+
     const PENDING = 1;
     const ACTIVE = 2;
     const BANNED = 3;
@@ -124,6 +126,7 @@ You can now easily do the following.
 * Easy to use to any framework or even a plain PHP file.
 * PSR-4 autoloading compliant structure.
 * Unit-Testing with PHPUnit.
+* Easy to set default enum value.
 
 ## Contributing
 

--- a/src/Enums/Enum.php
+++ b/src/Enums/Enum.php
@@ -19,10 +19,19 @@ abstract class Enum implements EnumContract, JsonSerializable
      */
     protected $enumValue;
 
+    /**
+     * The default value of the enum.
+     *
+     * @var int
+     */
+    protected $__default = null;
+    
     public function __construct($enumValue = null)
     {
         if (! is_null($enumValue)) {
             $this->set($enumValue);
+        } elseif (! is_null($this->__default)) {
+            $this->set($this->__default);
         }
     }
 

--- a/src/Enums/Enum.php
+++ b/src/Enums/Enum.php
@@ -25,7 +25,7 @@ abstract class Enum implements EnumContract, JsonSerializable
      * @var int
      */
     protected $__default = null;
-    
+
     public function __construct($enumValue = null)
     {
         if (! is_null($enumValue)) {


### PR DESCRIPTION
This PR will add features for default values addressing #1 

This, in my opinion, adds in the ability to set default values is the least impacting way possible. It's fairly similar to how SplEnums work, but uses a property instead of const.

When a default value is net set, nor an initial passed to the constructor the class will function the same as it does currently. However when a default value is defined and the initial value is not passed you will get an Enum set to the default.

## Breaking Changes

### PHP 5.3 Support Removed
This was done because PHP 5.3 is very EoL and should not be used anymore. Even anything under PHP 5.5 is questionable since those are also EoL and no longer getting security updates. However those versions are left supported since they don't cause breaking issues in tests.