### PR TITLE
add function to return enum keys

### DIFF
--- a/src/Enums/Enum.php
+++ b/src/Enums/Enum.php
@@ -39,6 +39,18 @@ abstract class Enum implements EnumContract, JsonSerializable
     }
 
     /**
+     * Returns all available keys on the enum.
+     *
+     * @return array
+     */
+    public static function keys()
+    {
+        $instance = new static();
+
+        return array_keys($instance->values());
+    }
+
+    /**
      * Returns the text equivalent for a specific enum value.
      *
      * @throws UndefinedEnumValueException

--- a/tests/EnumBasicTest.php
+++ b/tests/EnumBasicTest.php
@@ -29,6 +29,11 @@ class EnumBasicTest extends TestCase
         $this->assertTrue(is_array(UserStatus::all()));
     }
 
+    public function testEnumKeysMethod()
+    {
+        $this->assertTrue(is_array(UserStatus::keys()));
+    }
+
     public function testEnumValuesMethod()
     {
         $status = new UserStatus();


### PR DESCRIPTION
Adds a function to return an array with the enums keys.

Found that we're often calling `array_keys(Enum::all())` especially when working with string keys. This will shorten that call to `Enum::keys()`.