### PR TITLE
Update docblocks for string types

### DIFF
--- a/src/Enums/Enum.php
+++ b/src/Enums/Enum.php
@@ -15,7 +15,7 @@ abstract class Enum implements EnumContract, JsonSerializable
     /**
      * The current value of the enum.
      *
-     * @var int
+     * @var int|string
      */
     protected $enumValue;
 
@@ -55,7 +55,7 @@ abstract class Enum implements EnumContract, JsonSerializable
      *
      * @throws UndefinedEnumValueException
      *
-     * @return string
+     * @return int|string
      */
     public function get($enumValue)
     {
@@ -90,7 +90,7 @@ abstract class Enum implements EnumContract, JsonSerializable
     /**
      * Returns the current enum value.
      *
-     * @return int
+     * @return int|string
      */
     public function value()
     {


### PR DESCRIPTION
PHPStan doesn't always like comparing ints to strings like the current docblocks imply will happen. Since we mainly use strings this should help with that.