### PR TITLE
Make package 8.1.0 compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "type": "library",
     "require": {
-		"php": ">=5.3.0"
+		"php": ">=8.0.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "type": "library",
     "require": {
-		"php": ">=8.0.0"
+		"php": ">=5.3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2",

--- a/src/Enums/Enum.php
+++ b/src/Enums/Enum.php
@@ -121,7 +121,8 @@ abstract class Enum implements EnumContract, JsonSerializable
         return in_array($this->enumValue, $value);
     }
 
-    public function jsonSerialize(): mixed
+    #[\ReturnTypeWillChange]
+    public function jsonSerialize()
     {
         return $this->value();
     }

--- a/src/Enums/Enum.php
+++ b/src/Enums/Enum.php
@@ -121,7 +121,7 @@ abstract class Enum implements EnumContract, JsonSerializable
         return in_array($this->enumValue, $value);
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->value();
     }


### PR DESCRIPTION
When I ran my Laravel 9 project on PHP 8.1, I get this message on every API response:
```html
<br />
<b>Deprecated</b>:  Return type of Bryse\Enums\Enum: :jsonSerialize() should either be compatible with JsonSerializable: :jsonSerialize(): mixed, or the #[\ReturnTypeWillChange
] attribute should be used to temporarily suppress the notice in <b>/Users/<REDACTED>/Development/http/app/<REDACTED>/vendor/brysem/phpenums/src/Enums/Enum.php</b> on line <b>124</b><br />
```

This PR is to simply add the return type and up the version to the first compatible PHP version with that change.